### PR TITLE
Fixed backtick indents and Language type

### DIFF
--- a/articles/azure-signalr/signalr-quickstart-azure-functions-python.md
+++ b/articles/azure-signalr/signalr-quickstart-azure-functions-python.md
@@ -92,7 +92,7 @@ You can use this sample function as a template for your own functions.
 
 1. Edit *index/\__init\__.py* and replace the contents with the following code:
 
-  ```javascript
+  ```python
   import os
 
   import azure.functions as func
@@ -100,7 +100,7 @@ You can use this sample function as a template for your own functions.
   def main(req: func.HttpRequest) -> func.HttpResponse:
       f = open(os.path.dirname(os.path.realpath(__file__)) + '/../content/index.html')
       return func.HttpResponse(f.read(), mimetype='text/html')
-        ```
+  ```
 
 ### Create the negotiate function
 


### PR DESCRIPTION
Line 95 - Set the language of sample to python, was javascript.

Line 103 - Backticks needed to be unindented as it didn't close the text string.